### PR TITLE
Update UserMass.scala to remove following ratio bias

### DIFF
--- a/src/scala/com/twitter/graph/batch/job/tweepcred/UserMass.scala
+++ b/src/scala/com/twitter/graph/batch/job/tweepcred/UserMass.scala
@@ -12,9 +12,6 @@ case class UserMassInfo(userId: Long, mass: Double)
 object UserMass {
 
   private val currentTimestamp = Time.now.inMilliseconds
-  private val constantDivisionFactorGt_threshFriendsToFollowersRatioUMass = 5.0
-  private val threshAbsNumFriendsUMass = 500
-  private val threshFriendsToFollowersRatioUMass = 0.6
   private val deviceWeightAdditive = 0.5
   private val ageWeightAdditive = 0.2
   private val restrictedWeightMultiplicative = 0.1
@@ -51,19 +48,7 @@ object UserMass {
           score
         }
 
-      val friendsToFollowersRatio = (1.0 + numFollowings) / (1.0 + numFollowers)
-      val adjustedMass =
-        if (numFollowings > threshAbsNumFriendsUMass &&
-          friendsToFollowersRatio > threshFriendsToFollowersRatioUMass) {
-          mass / scala.math.exp(
-            constantDivisionFactorGt_threshFriendsToFollowersRatioUMass *
-              (friendsToFollowersRatio - threshFriendsToFollowersRatioUMass)
-          )
-        } else {
-          mass
-        }
-
-      Some(UserMassInfo(userId, adjustedMass))
+      Some(UserMassInfo(userId, mass))
     }
   }
 }


### PR DESCRIPTION
removed 
- threshAbsNumFriendsUMass
- threshFriendsToFollowersRatioUMass
- constantDivisionFactorGt_threshFriendsToFollowersRatioUMass 

These terms punish users who follow too many people. I can see why they were included, probably to negatively bias against people who follow 40k people and have 40k followers. But that kind of negative bias should be much more sophisticated than a simple heuristic like this.

The way it's written right now, if you're a new user and a highly curious person, you'd be getting punished for following people.